### PR TITLE
Revert "Bump spring-cloud-dependencies from 2020.0.3-SNAPSHOT to 2021.0.0-SNAPSHOT"

### DIFF
--- a/1128/pom.xml
+++ b/1128/pom.xml
@@ -22,7 +22,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
-		<spring-cloud.version>2021.0.0-SNAPSHOT</spring-cloud.version>
+		<spring-cloud.version>2020.0.3-SNAPSHOT</spring-cloud.version>
 	</properties>
 
 	<dependencies>

--- a/1200/pom.xml
+++ b/1200/pom.xml
@@ -18,7 +18,7 @@
 	<packaging>jar</packaging>
 
 	<properties>
-		<spring-cloud.version>2021.0.0-SNAPSHOT</spring-cloud.version>
+		<spring-cloud.version>2020.0.3-SNAPSHOT</spring-cloud.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<spock-spring.version>1.3-groovy-2.5</spock-spring.version>

--- a/1442/pom.xml
+++ b/1442/pom.xml
@@ -15,7 +15,7 @@
 	<packaging>jar</packaging>
 
 	<properties>
-		<spring-cloud.version>2021.0.0-SNAPSHOT</spring-cloud.version>
+		<spring-cloud.version>2020.0.3-SNAPSHOT</spring-cloud.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>

--- a/1516/pom.xml
+++ b/1516/pom.xml
@@ -16,7 +16,7 @@
 
 	<properties>
 		<java.version>1.8</java.version>
-		<spring-cloud.version>2021.0.0-SNAPSHOT</spring-cloud.version>
+		<spring-cloud.version>2020.0.3-SNAPSHOT</spring-cloud.version>
 	</properties>
 
 	<dependencyManagement>

--- a/1816/pom.xml
+++ b/1816/pom.xml
@@ -15,7 +15,7 @@
 	<description>Test openfeign with resilience4j</description>
 
 	<properties>
-		<spring-cloud.version>2021.0.0-SNAPSHOT</spring-cloud.version>
+		<spring-cloud.version>2020.0.3-SNAPSHOT</spring-cloud.version>
 	</properties>
 
 	<dependencies>

--- a/1900/pom.xml
+++ b/1900/pom.xml
@@ -15,7 +15,7 @@
 	<description>Decorate queues with webflux</description>
 	<properties>
 		<java.version>11</java.version>
-		<spring-cloud.version>2021.0.0-SNAPSHOT</spring-cloud.version>
+		<spring-cloud.version>2020.0.3-SNAPSHOT</spring-cloud.version>
 		<awaitility.version>4.0.3</awaitility.version>
 	</properties>
 	<dependencies>

--- a/866/pom.xml
+++ b/866/pom.xml
@@ -23,7 +23,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
-		<spring-cloud.version>2021.0.0-SNAPSHOT</spring-cloud.version>
+		<spring-cloud.version>2020.0.3-SNAPSHOT</spring-cloud.version>
 		<testcontainers.version>1.15.3</testcontainers.version>
 	</properties>
 

--- a/949/pom.xml
+++ b/949/pom.xml
@@ -23,7 +23,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
-		<spring-cloud.version>2021.0.0-SNAPSHOT</spring-cloud.version>
+		<spring-cloud.version>2020.0.3-SNAPSHOT</spring-cloud.version>
 	</properties>
 
 	<dependencies>

--- a/994/pom.xml
+++ b/994/pom.xml
@@ -23,7 +23,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
-		<spring-cloud.version>2021.0.0-SNAPSHOT</spring-cloud.version>
+		<spring-cloud.version>2020.0.3-SNAPSHOT</spring-cloud.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Reverts spring-cloud-samples/sleuth-issues#59

let's keep the current GA branch in `main`